### PR TITLE
tweak the getindex performance for LocalWindowCache

### DIFF
--- a/src/CachedViews/CachedViews.jl
+++ b/src/CachedViews/CachedViews.jl
@@ -3,30 +3,8 @@ module CachedViews
 using OffsetArrays
 import Base: size
 
-# The cache view protocol
-#
-# * `make_cache` creates a CachedView
-# * `in_cache` to check whether this is cached in `A`
-# * `getindex(A, i)`: return `missing` if `A[i]` is not cached
-# * `setindex!(A, v, i)`: to cache the data `A[i] = v`
-#
-# This protocol only specifies how cache data is retrived, whether the cache data is up-to-date is
-# not in the scope of it and it's all depends on package user to define the behavior.
-#
-# WIP: This protocol is only used to compute pairwise distances, there might be changes to make it
-# applicable to other tasks.
-
 abstract type CachedView{T, N} <: AbstractArray{T, N} end
 abstract type AbstractCacheStrategy end
-
-"""
-    is_cached(A::CachedView, i...)::Bool
-
-Check whether the value at index `i` is cached in `A`.
-
-This check does not guarantee that cached value is up-to-date.
-"""
-is_cached(A::CachedView, i::Int) = is_cached(A, Base._to_subscript_indices(A, i)...)
 
 export NullCache, LocalWindowCache
 

--- a/src/CachedViews/LocalWindowCache.jl
+++ b/src/CachedViews/LocalWindowCache.jl
@@ -1,18 +1,17 @@
-# cache strategy -- the interface
 struct LocalWindowCache{N} <: AbstractCacheStrategy
     window_size::NTuple{N, Int}
 end
 LocalWindowCache(window_size::Tuple) = LocalWindowCache{length(window_size)}(map(i->convert(Int, i), window_size))
-make_cache(T, S::LocalWindowCache{N}, axesA::NTuple{N}, axesB::NTuple{N}, args...) where N = LocalWindow{T}(axesA, axesB, S.window_size)
+make_cache(T, S::LocalWindowCache{N}, axesA::NTuple{N}, axesB::NTuple{N}, args...) where N = LocalWindowCacheArray{T}(axesA, axesB, S.window_size)
 
-# cache implementation
-struct LocalWindow{T, N, NA, AT<:AbstractArray{T, N}, IA, IB} <: CachedView{T, N}
+struct LocalWindowCacheArray{T, N, NA, AT<:AbstractArray{T, N}, IA, IB, IC} <: CachedView{T, N}
     cache::AT
     axesA::IA
     axesB::IB
+    R::IC
 end
 
-function LocalWindow{T}(axesA::NTuple{NA}, axesB::NTuple{NA}, window_size::NTuple{NA, Integer}) where {T, NA}
+function LocalWindowCacheArray{T}(axesA::NTuple{NA}, axesB::NTuple{NA}, window_size::NTuple{NA, Integer}) where {T, NA}
     window_ax = map(window_size) do w
         r = w ÷ 2
         -r:r
@@ -22,56 +21,13 @@ function LocalWindow{T}(axesA::NTuple{NA}, axesB::NTuple{NA}, window_size::NTupl
 
     FT = Union{Missing, T}
     cache = OffsetArray{FT, N}(missing, cache_ax)
-    LocalWindow{FT, N, length(axesA), typeof(cache), typeof(axesA), typeof(axesB)}(cache, axesA, axesB)
+
+    # https://github.com/JuliaArrays/OffsetArrays.jl/issues/166
+    # For OffsetArray, `axes(cache)` can be expensive to be done in each `getindex` call.
+    # Thus we cache the result and use it to accelerate checkbounds.
+    R = CartesianIndices(cache)
+    LocalWindowCacheArray{FT, N, length(axesA), typeof(cache), typeof(axesA), typeof(axesB), typeof(R)}(cache, axesA, axesB, R)
 end
 
-Base.axes(A::LocalWindow) = (A.axesA..., A.axesB...)
-Base.size(A::LocalWindow) = map(length, axes(A))
-
-@inline function cache_index(::LocalWindow{T, N, NA}, I::Vararg{Int, N}) where {T, N, NA}
-    i, j = I[1:NA], I[NA+1:end]
-    i, I[NA+1:end] .- i
-end
-
-@inline function is_cached(A::LocalWindow{T, N}, I::Vararg{Int, N}) where {T, N}
-    # if I is outside of axes(A), it's clearly that not in cache
-    i, o = cache_index(A, I...)
-    return checkbounds(Bool, A.cache, i..., o...)
-end
-
-Base.@propagate_inbounds function Base.getindex(A::LocalWindow{T, N}, I::Vararg{Int, N}) where {T, N}
-    @boundscheck checkbounds(A, I...)
-
-    i, o = cache_index(A, I...)
-    if checkbounds(Bool, A.cache, i..., o...)
-        return A.cache[i..., o...]
-    else
-        return missing
-    end
-end
-
-Base.@propagate_inbounds function Base.setindex!(A::LocalWindow{T, N}, v, I::Vararg{Int, N}) where {T, N}
-    i, o = cache_index(A, I...)
-    @boundscheck checkcache(A, I...)
-
-    A.cache[i..., o...] = v
-    return A
-end
-
-Base.@propagate_inbounds function Base.setindex!(A::LocalWindow, v, i::Int)
-    # delay the boundscheck in the IndexCartesian version and not set @inbounds meta here
-    setindex!(A, v, Base._to_subscript_indices(A, i)...)
-end
-
-@inline function checkcache(A::LocalWindow{T, N}, I::Vararg{Int, N}) where {T, N}
-    # This gives some performance boost https://github.com/JuliaLang/julia/issues/33273
-    _throw_argument_error() = throw(ArgumentError("LocalWindow do not support (re)setting the padding value. Consider making a copy of the array first."))
-    _throw_bounds_error(A, i) = throw(BoundsError(A, i))
-
-    if checkbounds(Bool, A, I...)
-        i, o = cache_index(A, I...)
-        checkbounds(Bool, A.cache, i..., o...) || _throw_argument_error()
-    else
-        _throw_bounds_error(A, I)
-    end
-end
+Base.axes(A::LocalWindowCacheArray) = (A.axesA..., A.axesB...)
+Base.size(A::LocalWindowCacheArray) = map(length, axes(A))

--- a/src/CachedViews/NullCache.jl
+++ b/src/CachedViews/NullCache.jl
@@ -4,8 +4,5 @@ struct NullCacheArray{T, N, IA, IB} <: CachedView{T, N}
     axesB::IB
 end
 make_cache(T, S::NullCache, axesA, axesB, args...) = NullCacheArray{T, length(axesA)+length(axesB), typeof(axesA), typeof(axesB)}(axesA, axesB)
-is_cached(::NullCacheArray, ::Int...) = false
-getindex(::NullCacheArray{T, N}, ::Vararg{Int, N}) where {T, N} = missing
-setindex!(::NullCacheArray{T, N}, v, ::Vararg{Int, N}) where {T, N} = v
 Base.axes(A::NullCacheArray) = (A.axesA..., A.axesB...)
 Base.size(A::NullCacheArray) = map(length, axes(A))

--- a/src/LazyDistances.jl
+++ b/src/LazyDistances.jl
@@ -3,9 +3,11 @@ module LazyDistances
 using Reexport
 using Distances
 
+include("utilities.jl")
 include("CachedViews/CachedViews.jl")
 @reexport using .CachedViews
-using .CachedViews: CachedView, AbstractCacheStrategy, NullCacheArray, LocalWindow, is_cached, make_cache, cache_index
+using .CachedViews: AbstractCacheStrategy, make_cache
+using .CachedViews: CachedView, NullCacheArray, LocalWindowCacheArray
 
 export PairwiseDistance
 

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -1,18 +1,26 @@
 """
-    PairwiseDistance(f, A, B, [cache_strategy=NullCache()])
+    PairwiseDistance([map_op,] f, A, B, [cache_strategy=NullCache()])
 
 Lazily calculate the pairwise result of two arrays `A`, `B` with function `f`.
 
-The output `dist::PairwiseDistance` is a read-only array type, where `dist[i, j]` is defined as
-`f(A[i], B[j])`.
+The output `dist::PairwiseDistance` is a read-only array type, where `dist[p, q]` is defined as
+`f(A[p], B[q])`. Each item `dist[p, q]` is computed lazily during `getindex`, which could be
+expensive for non-trivial `f`. `cache_strategy` provides a way to automatically store some of the
+result as cache.
 
-Each item `dist[i, j]` is computed lazily during `getindex`, which could be expensive for
-non-trivial `f`. `cache_strategy` provides a way to automatically store some of the result as cache.
-The default strategy is `NullCache()`, which means no cache is enabled.
+`map_op(p::CartesianIndex{N}, q::CartesianIndex{N}) where N` is used to map `p` in `A` and `q` in
+`B` to other data, e.g., column, row, block. The default version is `getindex`, i.e., `map_op(p, q)
+= A[p], B[q]`. The output of `map_op` is the input of `f` and thus you have to make sure these two
+function works seamlessly.
 
-!!! warning
-    How data is cached is internal implementation details and you generally should not talk
-    to cache directly.
+Two cache types are available:
+
+- `NullCache()` (default): no cache is used, every `getindex` does the actual computation.
+- `LocalWindowCache(window_size)`: use a cache array of size `(size(A)..., window_size...)`. For
+   each point `p`, it caches the results `f(A[p], B[q])` where `q ∈ p-r:p+r`, and `r` is the cache
+   window radius. This cache strategy has strong assumption on the spatial locality. This cache
+   strategy currently has an `getindex` overhead about 4-6ns and thus should not be applied to
+   trivial computations.
 
 # Examples
 
@@ -22,6 +30,15 @@ julia> using LazyDistances, Distances
 julia> A, B = rand(1:5, 6), rand(1:5, 4);
 
 julia> dist = PairwiseDistance(Euclidean(), A, B)
+6×4 PairwiseDistance{Float64, 2}:
+ 1.0  1.0  2.0  2.0
+ 4.0  4.0  1.0  1.0
+ 2.0  2.0  1.0  1.0
+ 4.0  4.0  1.0  1.0
+ 0.0  0.0  3.0  3.0
+ 2.0  2.0  1.0  1.0
+
+julia> dist = PairwiseDistance(Euclidean(), A, B, LocalWindowCache((3, )))
 6×4 PairwiseDistance{Float64, 2}:
  1.0  1.0  2.0  2.0
  4.0  4.0  1.0  1.0
@@ -49,7 +66,7 @@ end
 
 function PairwiseDistance(eval_op, A::AbstractArray, B::AbstractArray, cache_strategy::AbstractCacheStrategy=NullCache())
     PairwiseDistance(eval_op, A, B, cache_strategy) do p, q
-        A[p...], B[q...]
+        A[p], B[q]
     end
 end
 
@@ -66,42 +83,46 @@ function PairwiseDistance{T}(eval_op,
         B::AbstractArray,
         cache_strategy::AbstractCacheStrategy=NullCache()) where T
     PairwiseDistance{T}(eval_op, A, B, cache_strategy) do p, q
-        A[p...], B[q...]
+        A[p], B[q]
     end
 end
 
 Base.axes(dist::PairwiseDistance) = axes(dist.cache)
 Base.size(dist::PairwiseDistance) = map(length, axes(dist))
 
-Base.@propagate_inbounds function Base.getindex(dist::PairwiseDistance{T, N}, I::Vararg{Int, N})::T where {T, N}
-    @boundscheck checkbounds(dist, I...)
+Base.@propagate_inbounds _evaluate_getindex(dist, p, q) = dist.eval_op(dist.map_op(p, q)...)
 
-    # TODO: Currently, each getindex call has about 16ns overhead, which is quite large and even
-    # slows down the performance.
-    if is_cached(dist.cache, I...)
-        rst = @inbounds getindex(dist.cache, I...)
+Base.@propagate_inbounds function Base.getindex(dist::PairwiseDistance{T, N, NA}, I::Vararg{Int, N}) where {T, N, NA}
+    p, q = Base.IteratorsMD.split(I, Val(NA))
+    _getindex(dist, CartesianIndex(p), CartesianIndex(q))
+end
+
+Base.@propagate_inbounds function _getindex(
+        dist::PairwiseDistance{T, N, NA, M, F, CA},
+        p::CartesianIndex{NA}, q::CartesianIndex{NA}) where {T, N, NA, M, F, CA<:NullCacheArray}
+    _evaluate_getindex(dist, p, q)
+end
+
+Base.@propagate_inbounds function _getindex(
+        dist::PairwiseDistance{T, N, NA, M, F, CA},
+        p::CartesianIndex{NA}, q::CartesianIndex{NA})::T where {T, N, NA, M, F, CA<:LocalWindowCacheArray}
+    o = q - p
+    I = CartesianIndex(p.I..., o.I...)
+
+    # Cache might be smaller than the actual array size
+    if _in(I, dist.cache.R)
+        rst = @inbounds dist.cache.cache[I]
         if ismissing(rst)
-            rst = _evaluate_getindex(dist, I...)::T
-            @inbounds dist.cache[I...] = rst
+            rst = _evaluate_getindex(dist, p, q)
+            @inbounds dist.cache.cache[I] = rst
         end
-        return rst::T
+        return rst
     else
-        return _evaluate_getindex(dist, I...)
+        return _evaluate_getindex(dist, p, q)
     end
 end
 
-Base.@propagate_inbounds function Base.getindex(
-        dist::PairwiseDistance{T, N, NA, M, F, CA},
-        I::Vararg{Int, N}) where {T, N, NA, M, F, CA<:NullCacheArray}
-    _evaluate_getindex(dist, I...)
-end
-
-@inline function _evaluate_getindex(dist::PairwiseDistance{T, N, NA}, I::Vararg{Int, N}) where {T, N, NA}
-    p_val, q_val = dist.map_op(I[1:NA], I[NA+1:end])
-    dist.eval_op(p_val, q_val)::T
-end
-
-# To remove unnecessary information and get a clean view
+# To remove unnecessary information and get a clean view; cache should be transparent to user
 function Base.showarg(io::IO, ::PairwiseDistance{T, N}, toplevel) where {T, N}
     print(io, "PairwiseDistance{", T, ", ", N, "}")
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,0 +1,20 @@
+# a more efficient checkbounds implementation to minimize the overhead
+_checkbounds(::Type{Bool}, A::AbstractArray, I::CartesianIndex) = _in(I, CartesianIndices(A))
+function _checkbounds(::Type{Bool}, A::AbstractArray, p::CartesianIndex, q::CartesianIndex)
+    _checkbounds(Bool, A, CartesianIndex(p.I..., q.I...))
+end
+
+# # short-circuiting gives better performance
+@generated function _in(i::CartesianIndex{N}, r::CartesianIndices{N}) where N
+    ex = :()
+    for k = 1:N
+        ex = :($ex; i.I[$k] in r.indices[$k] || return false)
+    end
+    ex = :($ex; return true)
+end
+# _in(i::CartesianIndex, r::CartesianIndices) = _alltsc(map(in, i.I, r.indices))
+# @inline function _alltsc(t::Tuple{Bool,Vararg{Bool}})
+#     first(t) || return false
+#     return _alltsc(Base.tail(t))
+# end
+# _alltsc(::Tuple{}) = true


### PR DESCRIPTION
Changes:

* directly operate on the OffsetArray cache
* use faster `in` implementation

```julia
julia> using LazyDistances, Distances

julia> A, B = rand(1:5, 6), rand(1:5, 4);

julia> dist = PairwiseDistance(Euclidean(), A, B, LocalWindowCache((3, )))

julia> @btime getindex($dist, i, j) setup=(i=rand(axes(dist,1)); j=rand(axes(dist,2)))
  17.897 ns (1 allocation: 16 bytes) # PR
  20.465 ns (1 allocation: 16 bytes) # master
```