### PR TITLE
make index_map, getindex_op and As tuples

### DIFF
--- a/docs/examples/image processing/block_matching.jl
+++ b/docs/examples/image processing/block_matching.jl
@@ -94,7 +94,7 @@ patched_mean(img, rₚ)
 # A [`PairwiseDistance`](@ref) is a lazy array that mimics the output of pairwise distance.
 
 eval_op(x, y) = abs2(x - y)
-pointwise_dist = PairwiseDistance(eval_op, img, img); # 1.982 ns (0 allocations: 0 bytes)
+pointwise_dist = PairwiseDistance(eval_op, (img, img)); # 1.982 ns (0 allocations: 0 bytes)
 
 ## pointwise_dist[I, J] is defined as f(img[I], img[J])
 pq1 = pointwise_dist[CartesianIndex(1, 1), CartesianIndex(2, 2)]
@@ -110,7 +110,7 @@ valid_R = first(R)+rₚ:last(R)-rₚ
 ## For simplicity, we didn't deal with boundary condition here, so it will error
 ## when we index with `patchwise_dist[1, 1, 1, 1]`.
 patchwise_dist = let rₚ = rₚ, img = img
-    PairwiseDistance(SqEuclidean(), img, img) do i
+    PairwiseDistance(SqEuclidean(), (img, img)) do i
         i-rₚ:i+rₚ
     end
 end; # 4.903 ns (0 allocations: 0 bytes)
@@ -126,7 +126,7 @@ patchwise_dist[p, q] == sqeuclidean(img[p-rₚ:p+rₚ], img[q-rₚ:q+rₚ])
 function patched_mean_lazy(img, rₚ; num_patches=10)
     out = fill(zero(eltype(img)), axes(img))
 
-    patchwise_dist = PairwiseDistance(SqEuclidean(), img, img) do i
+    patchwise_dist = PairwiseDistance(SqEuclidean(), (img, img)) do i
         i-rₚ:i+rₚ
     end
 
@@ -141,7 +141,7 @@ function patched_mean_lazy(img, rₚ; num_patches=10)
 end
 
 ## @btime patched_mean_lazy($img, $rₚ);
-##  532.812 ms (26916 allocations: 131.63 MiB)
+##  643.413 ms (37015 allocations: 131.99 MiB)
 ## @btime patched_mean($img, $rₚ);
 ##  824.653 ms (23549 allocations: 130.86 MiB)
 patched_mean_lazy(img, rₚ) == patched_mean(img, rₚ)
@@ -154,7 +154,7 @@ patched_mean_lazy(img, rₚ) == patched_mean(img, rₚ)
 # pair `(p, q)`.
 
 eval_op(x, y) = abs2(x - y)
-pointwise_dist = PairwiseDistance(eval_op, img, img, LocalWindowCache((7, 7))); # 32.575 μs (3 allocations: 980.12 KiB)
+pointwise_dist = PairwiseDistance(eval_op, (img, img), LocalWindowCache((7, 7))); # 32.575 μs (3 allocations: 980.12 KiB)
 
 pq1 = pointwise_dist[CartesianIndex(1, 1), CartesianIndex(2, 2)]
 pq2 = eval_op(img[CartesianIndex(1, 1)], img[CartesianIndex(2, 2)])
@@ -163,7 +163,7 @@ pq1 == pq2
 # Instead of caching the result of pixel distances, we choose to cache the result of patch distances:
 
 patchwise_dist = let img=img, rₚ=rₚ
-    PairwiseDistance(SqEuclidean(), img, img, LocalWindowCache(size(img))) do i
+    PairwiseDistance(SqEuclidean(), (img, img), LocalWindowCache(size(img))) do i
         i-rₚ:i+rₚ
     end;
 end;
@@ -182,7 +182,7 @@ function patched_mean_cache(img, rₚ; num_patches=10)
     out = fill(zero(eltype(img)), axes(img))
 
     patchwise_dist = let rₚ=rₚ
-        PairwiseDistance(SqEuclidean(), img, img, LocalWindowCache(size(img))) do i
+        PairwiseDistance(SqEuclidean(), (img, img), LocalWindowCache(size(img))) do i
             i-rₚ:i+rₚ
         end;
     end;

--- a/src/CachedViews/LocalWindowCache.jl
+++ b/src/CachedViews/LocalWindowCache.jl
@@ -3,7 +3,7 @@ struct LocalWindowCache{N} <: AbstractCacheStrategy
     window_size::NTuple{N, Int}
 end
 LocalWindowCache(window_size::Tuple) = LocalWindowCache{length(window_size)}(map(i->convert(Int, i), window_size))
-make_cache(T, S::LocalWindowCache{N}, axesA::NTuple{N}, axesB::NTuple{N}, args...) where N = LocalWindowCacheArray{T}(axesA, axesB, S.window_size)
+make_cache(T, S::LocalWindowCache{N}, ax::Tuple) where N = LocalWindowCacheArray{T}(ax..., S.window_size)
 
 # cache implementation
 struct LocalWindowCacheArray{T, N, NA, AT<:AbstractArray{T, N}, IA, IB} <: CachedView{T, N}

--- a/src/CachedViews/NullCache.jl
+++ b/src/CachedViews/NullCache.jl
@@ -1,6 +1,8 @@
 struct NullCache <:AbstractCacheStrategy end
-function make_cache(T, ::NullCache, axesA, axesB, args...)
-    axes = (axesA..., axesB...)
+function make_cache(T, ::NullCache, ax_list)
+    axes = reduce(ax_list; init=()) do x, y
+        (x..., y...)
+    end
     NullCacheArray{T, length(axes), typeof(axes)}(axes)
 end
 

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -1,21 +1,37 @@
 """
-    PairwiseDistance([index_map], [getindex_op], f, A, B, [cache_strategy])
+    PairwiseDistance([index_map], [getindex_op], f, As, [cache_strategy])
 
-Lazily calculate the pairwise result of two array-like objects `A`, `B` with function `f`.
+Lazily calculate the pairwise result of array-like objects `As` with function `f`.
 
-The output `dist` is a read-only array with `dist[i, j]` defined as `f(p, q)`, where
-`ĩ, j̃ = index_map(i), index_map(j)`, and `p, q = getindex_op(A, ĩ), getindex_op(B, j̃)`.
+The output `dist` is a read-only array with `dist[i, j, ...]` defined as `f(p, q, ...)`, where
+`ĩ = index_map(i)`, and `p = getindex_op(As[1], ĩ)`. More formally speaking,
+
+```julia
+dist[inds...] = f(map(getindex_op, index_map, inds, As) do proj, σ, i, A
+    proj(A, σ(i))
+end)
+```
+
+# Required Arguments
+
+- `f`: A function or function-like object.
+- `As`: A tuple of arrays.
 
 # Optional Arguments
 
-- `index_map=identity`:
-  `index_map` is a function-like object that maps given index into a new index or indices.
-- `getindex_op=@view getindex`:
-  `getindex_op` is a funtion-like object that defines how `p` and `q` are get. By default it is
-  a viewed version of getindex (without data copy).
+- `index_map`:
+  `index_map` is a function or function-like object that maps given index into a new index or indices.
+  By default it is `identity`.
+- `getindex_op`:
+  `getindex_op` is a function or funtion-like object that defines how `p` and `q` are get.
+  By default it is a viewed version of getindex (without data copy). 
   If `getindex_op` is provided, then `index_map` should be provided, too.
 - `cache_strategy=NullCache()`:
   Specify the cache strategy.
+
+!!! tips
+    `index_map` and `getindex_op` can optionally be a tuple of length `length(As)`. In this case,
+    `index_map[i]` and `getindex_op[i]` will applied to `As[i]`.
 
 # Cache Strategies
 
@@ -62,65 +78,81 @@ julia> dist = PairwiseDistance(Euclidean(), A, B, LocalWindowCache((5, )))
  5.0  4.0  3.0  2.0
 ```
 """
-struct PairwiseDistance{T, N, NA, CA<:CachedView, M, G, F, AT, BT} <: AbstractArray{T, N}
+struct PairwiseDistance{T, N, NA, CA<:CachedView, M, G, F, TT} <: AbstractArray{T, N}
     index_map::M
     getindex_op::G
     f::F
-    A::AT
-    B::BT
+    As::TT
     cache::CA
     function PairwiseDistance{T}(
-            index_map::M, getindex_op::G, f::F,
-            A::AbstractArray{<:Any, NA}, B::AbstractArray{<:Any, NA},
-            cache_strategy::AbstractCacheStrategy=NullCache()) where {T,NA,M,G,F}
+            index_map::Tuple, getindex_op::Tuple, f::F,
+            As::NTuple{K, <:AbstractArray}, # for simplicity, assume As is homogeneous
+            cache_strategy::AbstractCacheStrategy=NullCache()) where {T,F,K}
 
-        cache = make_cache(T, cache_strategy, axes(A), axes(B))
-        new{T, 2NA, NA, typeof(cache), M, G, F, typeof(A), typeof(B)}(
-            index_map, getindex_op, f, A, B, cache
+        # TODO: support more array inputs... (Maybe...)
+        length(As) == 2 || throw(ArgumentError("Currently only two arrays are supported."))
+
+        NA = ndims(first(As))
+        all(isequal(NA), ndims.(As)) || throw(ArgumentError("`As` should be of the same dimension."))
+
+        cache = make_cache(T, cache_strategy, axes.(As))
+        new{T, K*NA, NA, typeof(cache), typeof(index_map), typeof(getindex_op), F, typeof(As)}(
+            index_map, getindex_op, f, As, cache
         )
     end
 end
 
 function PairwiseDistance(
         index_map, getindex_op, f,
-        A::AbstractArray, B::AbstractArray,
+        As::NTuple,
         cache_strategy::AbstractCacheStrategy=NullCache())
+    local T
     try
-        T = result_type(f, eltype(A), eltype(B))
-        return PairwiseDistance{T}(index_map, getindex_op, f, A, B, cache_strategy)
+        T = result_type(f, eltype.(As)...)
     catch e
-        @error "Unable to infer the result type, please specify it explicitly using `PairwiseDistance{T}`
-                method."
+        @error "Unable to infer the result type, please specify it explicitly using
+                the `PairwiseDistance{T}` althernative."
         rethrow(e)
     end
+    return PairwiseDistance{T}(index_map, getindex_op, f, As, cache_strategy)
 end
+
 function PairwiseDistance(
         index_map, f,
-        A::AbstractArray, B::AbstractArray,
+        As::NTuple,
         cache_strategy::AbstractCacheStrategy=NullCache())
     # If only two functions are provided, assume it's `index_map` and `f`.
-    PairwiseDistance(index_map, _getindex_view, f, A, B, cache_strategy)
+    PairwiseDistance(index_map, _getindex_view, f, As, cache_strategy)
 end
+
 function PairwiseDistance(
         f,
-        A::AbstractArray, B::AbstractArray,
+        As::NTuple,
         cache_strategy::AbstractCacheStrategy=NullCache())
-    PairwiseDistance(identity, _getindex_view, f, A, B, cache_strategy)
+    PairwiseDistance(identity, _getindex_view, f, As, cache_strategy)
 end
 
 function PairwiseDistance{T}(
         index_map, f,
-        A::AbstractArray,
-        B::AbstractArray,
+        As::NTuple,
         cache_strategy::AbstractCacheStrategy=NullCache()) where T
-    PairwiseDistance{T}(index_map, _getindex_view, f, A, B, cache_strategy)
+    PairwiseDistance{T}(index_map, _getindex_view, f, As, cache_strategy)
 end
+
 function PairwiseDistance{T}(
         f,
-        A::AbstractArray,
-        B::AbstractArray,
+        As::NTuple,
         cache_strategy::AbstractCacheStrategy=NullCache()) where T
-    PairwiseDistance{T}(identity, _getindex_view, f, A, B, cache_strategy)
+    PairwiseDistance{T}(identity, _getindex_view, f, As, cache_strategy)
+end
+
+function PairwiseDistance{T}(
+        index_map::M, getindex_op::G, f,
+        As::NTuple,
+        cache_strategy::AbstractCacheStrategy=NullCache()) where {T,M,G}
+    index_map isa Tuple || (index_map = ntuple(_->index_map, length(As)))
+    getindex_op isa Tuple || (getindex_op = ntuple(_->getindex_op, length(As)))
+    PairwiseDistance{T}(index_map, getindex_op, f, As, cache_strategy)
 end
 
 Base.axes(dist::PairwiseDistance) = axes(dist.cache)
@@ -156,10 +188,11 @@ Base.@propagate_inbounds function _getindex(
     end
 end
 
-Base.@propagate_inbounds function _evaluate_getindex(d::PairwiseDistance{T, N, NA}, p::CartesianIndex{NA}, q::CartesianIndex{NA}) where {T, N, NA}
-    p = d.getindex_op(d.A, _to_indices(d.index_map(p)))
-    q = d.getindex_op(d.B, _to_indices(d.index_map(q)))
-    convert(T, d.f(p, q))
+Base.@propagate_inbounds function _evaluate_getindex(d::PairwiseDistance{T, N, NA}, inds::CartesianIndex{NA}...) where {T, N, NA}
+    values = map(d.index_map, d.getindex_op, d.As, inds) do index_map, getindex_op, A, i
+        getindex_op(A, _to_indices(index_map(i)))
+    end
+    d.f(values...)
 end
 
 # To remove unnecessary information and get a clean view
@@ -171,9 +204,9 @@ end
 @inline _to_indices(inds::Tuple) = CartesianIndices(inds)
 @inline _to_indices(inds::Dims) = CartesianIndex(inds)
 @inline _to_indices(i::Union{Integer, CartesianIndex}) = i
-@inline _to_indices(R::CartesianIndices) = R
+@inline _to_indices(R::Union{CartesianIndices, AbstractArray{<:CartesianIndex}}) = R
 
-Base.@propagate_inbounds _getindex_view(A::AbstractArray, R::CartesianIndices) = @view A[R]
+Base.@propagate_inbounds _getindex_view(A::AbstractArray, R::Union{CartesianIndices, AbstractArray{<:CartesianIndex}}) = @view A[R]
 Base.@propagate_inbounds _getindex_view(A::AbstractArray, inds::Dims) = @view A[inds...]
 Base.@propagate_inbounds _getindex_view(A::AbstractArray, inds::Int...) = @view A[inds...]
 Base.@propagate_inbounds _getindex_view(A::AbstractArray, i::Union{Integer, CartesianIndex}) = A[i]

--- a/test/pairwise.jl
+++ b/test/pairwise.jl
@@ -33,46 +33,125 @@ end
         d = Euclidean()
 
         # (_, _, f)
-        dist = PairwiseDistance(d, A, B)
+        dist = PairwiseDistance(d, (A, B))
         @test eltype(dist) == result_type(d, A, B)
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, d, A, B)
 
         # {T}(_, _, f)
-        dist = PairwiseDistance{Float32}(d, A, B)
+        dist = PairwiseDistance{Float32}(d, (A, B))
         @test eltype(dist) == Float32
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, d, A, B)
 
         # (index_map, _, f)
-        index_map = i->CartesianIndex(1, 1)
-        dist = PairwiseDistance(index_map, d, A, B)
+        index_map = i->CartesianIndex(1)
+        dist = PairwiseDistance(index_map, d, (A, B))
         @test eltype(dist) == result_type(d, A, B)
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, index_map, d, A, B)
 
+        # (index_map_list, _, f)
+        index_map = (
+            i->CartesianIndex(1),
+            j->CartesianIndex(2)
+        )
+        dist = PairwiseDistance(index_map, d, (A, B))
+        @test eltype(dist) == result_type(d, A, B)
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test all(isequal(d(A[1], B[2])), dist)
+
         # {T}(index_map, _, f)
-        index_map = i->CartesianIndex(1, 1)
-        dist = PairwiseDistance{Float32}(index_map, d, A, B)
+        index_map = i->CartesianIndex(1)
+        dist = PairwiseDistance{Float32}(index_map, d, (A, B))
         @test eltype(dist) == Float32
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, index_map, d, A, B)
+
+        # {T}(index_map_list, _, f)
+        index_map = (
+            i->CartesianIndex(1),
+            j->CartesianIndex(2)
+        )
+        dist = PairwiseDistance{Float32}(index_map, d, (A, B))
+        @test eltype(dist) == Float32
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test all(isequal(d(A[1], B[2])), dist)
 
         # (index_map, getindex_op, f)
         index_map = i->i[1]
         getindex_op = (A, i)->i
-        dist = PairwiseDistance(index_map, getindex_op, d, A, B)
+        dist = PairwiseDistance(index_map, getindex_op, d, (A, B))
         @test eltype(dist) == result_type(d, A, B)
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, index_map, getindex_op, d, A, B)
 
+        # (index_map, getindex_op, f)
+        index_map = i->i[1]
+        getindex_op = (A, i)->i
+        dist = PairwiseDistance(index_map, getindex_op, d, (A, B))
+        @test eltype(dist) == result_type(d, A, B)
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test equality_test(dist, index_map, getindex_op, d, A, B)
+
+        # (index_map_list, getindex_op_list, f)
+        index_map = (
+            i->i[1],
+            j->j[1]
+        )
+        getindex_op = (
+            (A, i)->i,
+            (A, j)->j
+        )
+        dist = PairwiseDistance(index_map, getindex_op, d, (A, B))
+        @test eltype(dist) == result_type(d, A, B)
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test equality_test(dist, index_map[1], getindex_op[1], d, A, B)
+
         # {T}(index_map, getindex_op, f)
         index_map = i->i[1]
         getindex_op = (A, i)->i
-        dist = PairwiseDistance{Float32}(index_map, getindex_op, d, A, B)
+        dist = PairwiseDistance{Float32}(index_map, getindex_op, d, (A, B))
         @test eltype(dist) == Float32
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, index_map, getindex_op, d, A, B)
+
+        # (index_map_list, getindex_op_list, f)
+        index_map = (
+            i->i[1],
+            j->j[1]
+        )
+        getindex_op = (
+            (A, i)->i,
+            (A, j)->j
+        )
+        dist = PairwiseDistance{Float32}(index_map, getindex_op, d, (A, B))
+        @test eltype(dist) == Float32
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test equality_test(dist, index_map[1], getindex_op[1], d, A, B)
+
+        @testset "Invalid cases" begin
+            # all inputs should be tuple
+
+            index_map = [
+                i->i[1],
+                j->j[1]
+            ]
+            getindex_op = [
+                (A, i)->i,
+                (A, j)->j
+            ]
+            dist = PairwiseDistance{Float32}(index_map, getindex_op, d, (A, B));
+            @test_throws MethodError dist[1, 1]
+
+            @test_throws MethodError PairwiseDistance(d, A, B);
+            @test_throws MethodError PairwiseDistance{Float32}(d, A, B);
+            @test_throws MethodError PairwiseDistance(index_map, getindex_op, d, A, B);
+            @test_throws MethodError PairwiseDistance{Float32}(index_map, getindex_op, d, A, B);
+
+            # Currently we only support two arrays
+            @test_throws ArgumentError PairwiseDistance{Float32}(d, (A, B, A));
+        end
     end
 
     @testset "LocalWindowCache" begin
@@ -80,45 +159,124 @@ end
         d = Euclidean()
 
         # (_, _, f)
-        dist = PairwiseDistance(d, A, B, LocalWindowCache((4, )))
+        dist = PairwiseDistance(d, (A, B), LocalWindowCache((4, )))
         @test eltype(dist) == result_type(d, A, B)
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, d, A, B)
 
         # {T}(_, _, f)
-        dist = PairwiseDistance{Float32}(d, A, B, LocalWindowCache((4, )))
+        dist = PairwiseDistance{Float32}(d, (A, B), LocalWindowCache((4, )))
         @test eltype(dist) == Float32
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, d, A, B)
 
         # (index_map, _, f)
-        index_map = i->CartesianIndex(1, 1)
-        dist = PairwiseDistance(index_map, d, A, B, LocalWindowCache((4, )))
+        index_map = i->CartesianIndex(1)
+        dist = PairwiseDistance(index_map, d, (A, B), LocalWindowCache((4, )))
         @test eltype(dist) == result_type(d, A, B)
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, index_map, d, A, B)
 
+        # (index_map_list, _, f)
+        index_map = (
+            i->CartesianIndex(1),
+            j->CartesianIndex(2)
+        )
+        dist = PairwiseDistance(index_map, d, (A, B), LocalWindowCache((4, )))
+        @test eltype(dist) == result_type(d, A, B)
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test all(isequal(d(A[1], B[2])), dist)
+
         # {T}(index_map, _, f)
-        index_map = i->CartesianIndex(1, 1)
-        dist = PairwiseDistance{Float32}(index_map, d, A, B, LocalWindowCache((4, )))
+        index_map = i->CartesianIndex(1)
+        dist = PairwiseDistance{Float32}(index_map, d, (A, B), LocalWindowCache((4, )))
         @test eltype(dist) == Float32
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, index_map, d, A, B)
+
+        # {T}(index_map_list, _, f)
+        index_map = (
+            i->CartesianIndex(1),
+            j->CartesianIndex(2)
+        )
+        dist = PairwiseDistance{Float32}(index_map, d, (A, B), LocalWindowCache((4, )))
+        @test eltype(dist) == Float32
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test all(isequal(d(A[1], B[2])), dist)
 
         # (index_map, getindex_op, f)
         index_map = i->i[1]
         getindex_op = (A, i)->i
-        dist = PairwiseDistance(index_map, getindex_op, d, A, B, LocalWindowCache((4, )))
+        dist = PairwiseDistance(index_map, getindex_op, d, (A, B), LocalWindowCache((4, )))
         @test eltype(dist) == result_type(d, A, B)
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, index_map, getindex_op, d, A, B)
 
+        # (index_map, getindex_op, f)
+        index_map = i->i[1]
+        getindex_op = (A, i)->i
+        dist = PairwiseDistance(index_map, getindex_op, d, (A, B), LocalWindowCache((4, )))
+        @test eltype(dist) == result_type(d, A, B)
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test equality_test(dist, index_map, getindex_op, d, A, B)
+
+        # (index_map_list, getindex_op_list, f)
+        index_map = (
+            i->i[1],
+            j->j[1]
+        )
+        getindex_op = (
+            (A, i)->i,
+            (A, j)->j
+        )
+        dist = PairwiseDistance(index_map, getindex_op, d, (A, B), LocalWindowCache((4, )))
+        @test eltype(dist) == result_type(d, A, B)
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test equality_test(dist, index_map[1], getindex_op[1], d, A, B)
+
         # {T}(index_map, getindex_op, f)
         index_map = i->i[1]
         getindex_op = (A, i)->i
-        dist = PairwiseDistance{Float32}(index_map, getindex_op, d, A, B, LocalWindowCache((4, )))
+        dist = PairwiseDistance{Float32}(index_map, getindex_op, d, (A, B), LocalWindowCache((4, )))
         @test eltype(dist) == Float32
         @test axes(dist) == (axes(A, 1), axes(B, 1))
         @test equality_test(dist, index_map, getindex_op, d, A, B)
+
+        # (index_map_list, getindex_op_list, f)
+        index_map = (
+            i->i[1],
+            j->j[1]
+        )
+        getindex_op = (
+            (A, i)->i,
+            (A, j)->j
+        )
+        dist = PairwiseDistance{Float32}(index_map, getindex_op, d, (A, B), LocalWindowCache((4, )))
+        @test eltype(dist) == Float32
+        @test axes(dist) == (axes(A, 1), axes(B, 1))
+        @test equality_test(dist, index_map[1], getindex_op[1], d, A, B)
+
+        @testset "Invalid cases" begin
+            # all inputs should be tuple
+
+            index_map = [
+                i->i[1],
+                j->j[1]
+            ]
+            getindex_op = [
+                (A, i)->i,
+                (A, j)->j
+            ]
+            dist = PairwiseDistance{Float32}(index_map, getindex_op, d, (A, B), LocalWindowCache((4, )));
+            @test_throws MethodError dist[1, 1]
+
+            @test_throws MethodError PairwiseDistance(d, A, B, LocalWindowCache((4, )));
+            @test_throws MethodError PairwiseDistance{Float32}(d, A, B, LocalWindowCache((4, )));
+            @test_throws MethodError PairwiseDistance(index_map, getindex_op, d, A, B, LocalWindowCache((4, )));
+            @test_throws MethodError PairwiseDistance{Float32}(index_map, getindex_op, d, A, B, LocalWindowCache((4, )));
+
+            # Currently we only support two arrays
+            @test_throws ArgumentError PairwiseDistance{Float32}(d, (A, B, A), LocalWindowCache((4, )));
+        end
     end
 end


### PR DESCRIPTION
```julia
using LazyDistances, Distances
using BenchmarkTools

function naive_pairwise_sum(d, X, Y)
    return sum(pairwise(d, X, Y))
end

function lazy_pairwise_sum(d, X, Y)
    getindex_op = (
        (ax, i) -> view(X, :, i),
        (ax, j) -> view(Y, :, j)
    )
    dist = PairwiseDistance(identity, getindex_op, d, map(A->axes(A, 2), (X, Y)))
    sum(dist)
end

function test(n)
    X = rand(1:10, 100n, 200n);
    Y = rand(1:10, 100n, 300n);

    d = Euclidean()
    @assert naive_pairwise_sum(d, X, Y) ≈ lazy_pairwise_sum(d, X, Y)
    
    t_naive = @belapsed naive_pairwise_sum($d, $X, $Y)
    t_lazy = @belapsed lazy_pairwise_sum($d, $X, $Y)
    @show t_naive/t_lazy
    return t_naive/t_lazy
end

boostup = map(test, [1, 2, 5, 10])
```

and we get

```julia
4-element Vector{Float64}:
 1.0138489385160674
 1.684934018538836
 2.583994866523499
 2.210065122627724
```